### PR TITLE
add-title-to-inspo-img

### DIFF
--- a/app/assets/javascripts/lessons.coffee
+++ b/app/assets/javascripts/lessons.coffee
@@ -26,11 +26,13 @@
     $inspiration_image = $('.inspiration-image')
     return unless $inspiration_image.length > 0
     url = $inspiration_image.data('large-url')
+    title = $inspiration_image.data('title')
     description = $inspiration_image.data('description')
     $inspiration = $('#inspiration')
     $el = $("""
       <blockquote>
         <img src='#{url}'/>
+        #{title}
         #{description}
       </blockquote>
       """)

--- a/app/controllers/admin/lessons_controller.rb
+++ b/app/controllers/admin/lessons_controller.rb
@@ -62,6 +62,6 @@ class Admin::LessonsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def lesson_params
-      params.require(:lesson).permit(:title, :project_id, :overview, :example_image, :inspiration_image, :inspiration_image_description, :video_uri, sections_attributes: [:id, :order, :content])
+      params.require(:lesson).permit(:title, :project_id, :overview, :example_image, :inspiration_image, :inspiration_image_title, :inspiration_image_description, :video_uri, sections_attributes: [:id, :order, :content])
     end
 end

--- a/app/views/admin/lessons/_form.html.erb
+++ b/app/views/admin/lessons/_form.html.erb
@@ -1,4 +1,4 @@
-<% path = @lesson.persisted? ? admin_lesson_path(@lesson) : admin_lessons_path %> 
+<% path = @lesson.persisted? ? admin_lesson_path(@lesson) : admin_lessons_path %>
 <%= form_for @lesson, url: path do |f| %>
   <% if @lesson.errors.any? %>
     <div id="error_explanation">
@@ -19,7 +19,7 @@
       <%= options_for_select ProjectSet.all.map { |p| [p.title, p.slug] }, ProjectSet.count %>
     </select>
   </div>
-  
+
   <div class="field">
     <%= label_tag :project_level %>
     <select id="project_level" name="project_level">
@@ -33,29 +33,34 @@
     <%= f.text_field :title %>
   </div>
 
-  <%= render "shared/form_attachment", 
-    form: f, 
+  <%= render "shared/form_attachment",
+    form: f,
     entity: @lesson,
     attribute: :overview,
     label: "Lesson Overview PDF" %>
 
-  <%= render "shared/form_attachment", 
-    form: f, 
+  <%= render "shared/form_attachment",
+    form: f,
     entity: @lesson,
     attribute: :example_image,
     label: "Example Image" %>
 
-  <%= render "shared/form_attachment", 
-    form: f, 
+  <%= render "shared/form_attachment",
+    form: f,
     entity: @lesson,
     attribute: :inspiration_image,
     label: "Inspiration Image" %>
+
+    <div class="field">
+      <%= f.label :inspiration_image_title %>
+      <%= f.text_field :inspiration_image_title %>
+    </div>
 
   <div class="field">
     <%= f.label :inspiration_image_description %>
     <%= f.text_field :inspiration_image_description %>
   </div>
-  
+
   <div class="field">
     <%= f.label :video_uri, "Video URL" %>
     <%= f.text_field :video_uri %>

--- a/app/views/admin/lessons/show.html.erb
+++ b/app/views/admin/lessons/show.html.erb
@@ -5,7 +5,7 @@
 <p>Title: <%= @lesson.title %>
 <p>Url: <%= lesson_link @lesson %></p>
 <p>
-  Project: <%= link_to @lesson.project.title, 
+  Project: <%= link_to @lesson.project.title,
     admin_project_set_path(@lesson.project.project_set) %>
 </p>
 <p>
@@ -15,7 +15,7 @@
 
 
 <p>
-  <% if @lesson.overview.present? %> 
+  <% if @lesson.overview.present? %>
   <%= link_to "Lesson Overview PDF", @lesson.overview.url %>
   <% else %>
   <%= "Lesson Overview PDF Not Found" %>
@@ -23,6 +23,7 @@
 </p>
 <p><%= image_tag @lesson.inspiration_image.url(:thumb) %></p>
 <p><%= image_tag @lesson.example_image.url(:thumb) %></p>
+<p>Inspiration Image Title: <%= @lesson.inspiration_image_title %></p>
 <p>Inspiration Image Description: <%= @lesson.inspiration_image_description %></p>
 
 

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -42,7 +42,7 @@
 </div>
 
 <% if @lesson.inspiration_image.exists? %>
-  <div class="hidden inspiration-image" data-medium-url="<%= @lesson.inspiration_image.url(:medium) %>" data-large-url="<%= @lesson.inspiration_image.url(:large) %>" data-description="<%= markdown @lesson.inspiration_image_description %>"></div>
+  <div class="hidden inspiration-image" data-medium-url="<%= @lesson.inspiration_image.url(:medium) %>" data-large-url="<%= @lesson.inspiration_image.url(:large) %>" data-title="<%= markdown @lesson.inspiration_image_title %>" data-description="<%= markdown @lesson.inspiration_image_description %>"></div>
 <% end %>
 
 <% if @lesson.video_uri.present? %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160406074055) do
+ActiveRecord::Schema.define(version: 20160422203711) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -88,6 +88,7 @@ ActiveRecord::Schema.define(version: 20160406074055) do
     t.string   "example_image_content_type"
     t.integer  "example_image_file_size"
     t.datetime "example_image_updated_at"
+    t.string   "inspiration_image_title"
   end
 
   add_index "lessons", ["project_id"], name: "index_lessons_on_project_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160422203711) do
+ActiveRecord::Schema.define(version: 20160423004610) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
@phantummm or @rjsheperd Will you look at this for me?

What I did was add a field for an inspiration image title to be added to each lesson in addition to the inspiration image description.  Tempest requested this so that we could separate the two for clarity.

Everything looks good on my local machine, but it's the first time I've really worked with the db, and I want to be careful about pushing to the master.

I pulled it down to a different machine, and it seems like you have to manually create the migration:

`rails g migration AddInspirationImageTittleToLessons inspiration_image_title:string`

Is there a way of making that happen automatically?

Give me any feedback!