### PR TITLE
changed basic markdown structure & added lesson_description to lesson…

### DIFF
--- a/app/controllers/admin/lessons_controller.rb
+++ b/app/controllers/admin/lessons_controller.rb
@@ -64,7 +64,7 @@ class Admin::LessonsController < ApplicationController
     def lesson_params
       params.require(:lesson).permit(
         :order, :title, :project_id, :overview, :example_image, :inspiration_image,
-        :inspiration_image_description, :video_uri, sections_attributes: [:id, :order, :content]
+        :inspiration_image_description, :lesson_description, :video_uri, sections_attributes: [:id, :order, :content]
       )
     end
 end

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -14,7 +14,7 @@ class Lesson < ActiveRecord::Base
   alias_attribute :name, :title
   after_initialize :set_order
 
-  has_sections overview: [:synopsis, :objective, :setup, :media, :photocopies, ], instructions: [:inspiration, :introduction, 'Independent Worktime', 'Clean Up/Presenations'], issues: [:anticipated_problems, :early_finishers]
+  has_sections overview: [:synopsis, :objective, :setup, :materials, :photocopies, :media, ], lesson: [:inspiration, :introduction, 'Worktime', 'Clean Up/Presentations'], extension: [:anticipated_problems, :early_finishers]
 
   has_attached_file :example_image,
     styles: { large: "900x900>", medium: "300x300>", thumb: "100x100>" },

--- a/app/views/admin/lessons/_form.html.erb
+++ b/app/views/admin/lessons/_form.html.erb
@@ -1,4 +1,4 @@
-<% path = @lesson.persisted? ? admin_lesson_path(@lesson) : admin_lessons_path %> 
+<% path = @lesson.persisted? ? admin_lesson_path(@lesson) : admin_lessons_path %>
 <%= form_for @lesson, url: path do |f| %>
   <% if @lesson.errors.any? %>
     <div id="error_explanation">
@@ -19,7 +19,7 @@
       <%= options_for_select ProjectSet.all.map { |p| [p.title, p.slug] }, ProjectSet.count %>
     </select>
   </div>
-  
+
   <div class="field">
     <%= label_tag :project_level %>
     <select id="project_level" name="project_level">
@@ -38,20 +38,20 @@
     <%= f.text_field :title %>
   </div>
 
-  <%= render "shared/form_attachment", 
-    form: f, 
+  <%= render "shared/form_attachment",
+    form: f,
     entity: @lesson,
     attribute: :overview,
     label: "Lesson Overview PDF" %>
 
-  <%= render "shared/form_attachment", 
-    form: f, 
+  <%= render "shared/form_attachment",
+    form: f,
     entity: @lesson,
     attribute: :example_image,
     label: "Example Image" %>
 
-  <%= render "shared/form_attachment", 
-    form: f, 
+  <%= render "shared/form_attachment",
+    form: f,
     entity: @lesson,
     attribute: :inspiration_image,
     label: "Inspiration Image" %>
@@ -60,7 +60,12 @@
     <%= f.label :inspiration_image_description %>
     <%= f.text_field :inspiration_image_description %>
   </div>
-  
+
+  <div class="field">
+    <%= f.label :lesson_description %>
+    <%= f.text_field :lesson_description %>
+  </div>
+
   <div class="field">
     <%= f.label :video_uri, "Video URL" %>
     <%= f.text_field :video_uri %>

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -15,9 +15,15 @@
       <div class="student-image">
         <%= image_tag @lesson.example_image.url(:medium) %>
       </div>
-      <div class="superhero-quote">
-        <%= @lesson.synopsis %>
-      </div>
+      <% if @lesson.lesson_description != "" %>
+        <div class="superhero-quote">
+          <%= @lesson.lesson_description %>
+        </div>
+      <% else %>
+        <div class="superhero-quote">
+          <%= @lesson.synopsis %>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/db/migrate/20160511232343_add_lesson_description_to_lessons.rb
+++ b/db/migrate/20160511232343_add_lesson_description_to_lessons.rb
@@ -1,0 +1,5 @@
+class AddLessonDescriptionToLessons < ActiveRecord::Migration
+  def change
+    add_column :lessons, :lesson_description, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160422221121) do
+ActiveRecord::Schema.define(version: 20160511232343) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -95,6 +95,8 @@ ActiveRecord::Schema.define(version: 20160422221121) do
     t.string   "example_image_content_type"
     t.integer  "example_image_file_size"
     t.datetime "example_image_updated_at"
+    t.string   "inspiration_image_title"
+    t.string   "lesson_description"
   end
 
   add_index "lessons", ["project_id"], name: "index_lessons_on_project_id", using: :btree


### PR DESCRIPTION
I changed the basic markdown structure & added a column to lessons for a lesson_description that can take the place of the synopsis.  There's a conditional in the lessons view show.html.erb so the markdown can be left as is on already existing lessons (so those will not have to be rebuilt) while allowing new lessons to be entered in a way more in accordance with what Tempest would like to see.

This is a kind of test for a way we could refactor the way lessons are built for the entire site while leaving alone the existing data so that Tempest doesn't have to re-enter all lessons.

Make sense?