### PR TITLE
Add ability to use S3 creds in development via env variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ node_modules/*
 
 # <alex> I use this file locally for a personal task list...
 TODO.md
+
+# @alex - I use this for tokens and stuff
+local_env.sh

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -26,5 +26,17 @@ Rails.application.configure do
   config.assets.debug = true
   config.assets.digest = true
   config.assets.raise_runtime_errors = true
-  puts "PATHS: #{config.assets.paths.join(', ')}"
+
+  if ENV['SHOW_S3_ASSETS'].present?
+    config.paperclip_defaults = {
+      :storage => :s3,
+      :s3_credentials => {
+        :bucket => ENV['S3_BUCKET_NAME'],
+        :access_key_id => ENV['AWS_ACCESS_KEY_ID'],
+        :secret_access_key => ENV['AWS_SECRET_ACCESS_KEY']
+      },
+      :s3_region => ENV['S3_REGION'],
+      :s3_host_name => ENV['S3_HOST_NAME']
+    }
+  end
 end


### PR DESCRIPTION
Issue #166 

It's annoying that we can't see S3 assets when we're running in local environment, so this will fix it so that we have the option of using environment variables to pass in credentials for S3.

I have a separate `local_env.sh` file with the [in my case production] credentials, which I can give to @jasonoverby if he wants them. Once I `source` that, I just run the Rails server with an added toggle like: `SHOW_S3_ASSETS=1 bin/rails s`