### PR TITLE
added redirect to thanks page after sign_up

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -38,6 +38,7 @@ class UsersController < ApplicationController
   end
 
   def artroom
+    redirect_to thanks_path unless @visits.to_i > 1
     redirect_to '/users/sign_in' unless current_user.present?
   end
 

--- a/app/views/subscriptions/thanks.html.erb
+++ b/app/views/subscriptions/thanks.html.erb
@@ -1,6 +1,6 @@
 <div class='thanks'>
-  <h2>Thank you for subscribing to our mailing list</h2>
+  <h2>Thank you!!</h2>
   <p>You'll receive periodic updates about the Doodles community and notifications of new lessons and projects as they're added. We'd love to hear your feedback and thoughts on our <%= link_to 'contact page', contact_path %>, or feel free to email us at <a href="mailto:feedback@doodles-academy.org">feedback@doodles-academy.org</a>.</p>
   <p>Have a creative day!</p>
-  <p class="low-set"><%= link_to "Back to the front page", root_path %></p>
+  <p class="low-set"><%= link_to "To the artroom!", artroom_path %></p>
 </div>


### PR DESCRIPTION
@phantummm In order to redirect to `thanks_path` after signup I added a simple check within the artroom page.  I would maybe prefer to have this automatically happen as a consequence of signing up, but I'm not sure how to work that out via devise.  To test, use Firefox or some other browser you rarely use, delete cookies from Doodles, and then sign up as a new user.

We can modify the thanks page to Tempest's specs if necessary.