### PR TITLE
Subscribe new users to MailChimp

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,13 +47,13 @@ class User < ActiveRecord::Base
   def subscription_params
     {
       id: nil,
-      email: self.email,
-      first_name: self.profile.present? ? self.profile.first_name : '',
-      last_name: self.profile.present? ? self.profile.last_name : ''
+      email: email,
+      first_name: profile.try(:first_name),
+      last_name: profile.try(:last_name)
     }
   end
 
   def subscribe_to_mailing_list
-    SubscriptionService.new(self.subscription_params).subscribe
+    SubscriptionService.new(subscription_params).subscribe
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,7 @@ class User < ActiveRecord::Base
   default_scope { where(status: User.statuses[:active]) }
 
   after_initialize :set_role
+  after_create :subscribe_to_mailing_list
 
   has_many :projects
 
@@ -43,4 +44,16 @@ class User < ActiveRecord::Base
     self.role ||= 'visitor'
   end
 
+  def subscription_params
+    {
+      id: nil,
+      email: self.email,
+      first_name: self.profile.present? ? self.profile.first_name : '',
+      last_name: self.profile.present? ? self.profile.last_name : ''
+    }
+  end
+
+  def subscribe_to_mailing_list
+    SubscriptionService.new(self.subscription_params).subscribe
+  end
 end

--- a/app/services/subscription_service.rb
+++ b/app/services/subscription_service.rb
@@ -38,8 +38,8 @@ class SubscriptionService
         email_address: @email_address,
         status: "subscribed",
         merge_fields: {
-          FNAME: subscription_params[:first_name],
-          LNAME: subscription_params[:last_name]
+          FNAME: @subscription_params[:first_name],
+          LNAME: @subscription_params[:last_name]
         }
       }
     }

--- a/app/services/subscription_service.rb
+++ b/app/services/subscription_service.rb
@@ -27,7 +27,11 @@ class SubscriptionService
     {
       body: {
         email_address: @email_address,
-        status: "subscribed"
+        status: "subscribed",
+        merge_fields: {
+          FNAME: @subscription_params[:first_name],
+          LNAME: @subscription_params[:last_name]
+        }
       }
     }
   end


### PR DESCRIPTION
- Add an `after_create` callback to the `User` model, subscribing a newly created user to the MailChimp mailing list.